### PR TITLE
Add x86 image in addition to arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           push: true
           pull: true
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,22 @@ RUN apt-get update \
     && apt-get install -y \
        curl
 
+RUN curl -sSL https://git.io/get-mo -o /usr/local/bin/mo \
+    && chmod +x /usr/local/bin/mo
+
 ARG COMMENT="Adding DOTE..."
-ARG DOTE_URL="https://github.com/chrisstaite/DoTe/releases/latest/download/dote_arm64"
+ARG DOTE_URL="https://github.com/chrisstaite/DoTe/releases/latest/download/dote_{{SUFFIX}}"
 
 RUN echo $COMMENT \
+    && export SUFFIX="$( test "${TARGETARCH}" = "arm64" && echo "${TARGETARCH}" || echo linux )" \
+    && export DOTE_URL="$( echo "${DOTE_URL}" | mo -u)" \
     && curl -fsSLo /usr/local/bin/dote "${DOTE_URL}" \
     && chmod +x /usr/local/bin/dote
 
 FROM pihole/pihole:${PIHOLE_VERSION}
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 ENV DOTE_OPTS="-s 127.0.0.1:5053"
 RUN addgroup \
         --system \


### PR DESCRIPTION
Use the `${TARGETARCH}` [built-in argument](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope) to fetch the appropriate version of DoTE

The main downside of this approach is that it requires the BuildKit backend